### PR TITLE
compositions can load classes from other compositions

### DIFF
--- a/compositions/sample/index.js
+++ b/compositions/sample/index.js
@@ -1,0 +1,17 @@
+define.class(function(teem, server, screens, screen, view, text, samplext$sserver, samplext$sview) {
+
+    this.render = function() {
+        return [
+            screens(
+                screen(
+                    view(
+                        { x:100, y:100, height: 500, width:300, bgcolor:"pink" },
+                        samplext$sview({x:10, y:10})
+                    )
+                )
+            ),
+            samplext$sserver()
+        ]
+    }
+
+});

--- a/compositions/samplext/index.js
+++ b/compositions/samplext/index.js
@@ -1,0 +1,7 @@
+define.class(function(sample$index) {
+
+    this.render = function() {
+        return sample$index();
+    }
+
+});

--- a/compositions/samplext/sserver.js
+++ b/compositions/samplext/sserver.js
@@ -1,0 +1,8 @@
+define.class(function(server){
+    this.render = function(){ return [
+        server({init:function(){
+            console.log('Wow, this worked.')
+        }})
+    ]}
+
+});

--- a/compositions/samplext/sview.js
+++ b/compositions/samplext/sview.js
@@ -1,0 +1,12 @@
+define.class(function(view, text){
+
+    this.height = 50;
+
+    this.render = function() {
+        return view({height: 50, width:150, bgcolor:"red"}, text({width:150, height:20, text:'did it work?', y:5, x:5}))
+    };
+
+});
+
+
+

--- a/define.js
+++ b/define.js
@@ -22,6 +22,8 @@
 	define.$lib = "$root/lib"
 	define.$build = "$root/build"
 	define.$compositions = "$root/compositions"
+	//defaults to allowing all compositions to be used as resources for each other, but can be changed if needed for security reasons.
+	define.$plugins = "$compositions"
 	define.$tests = '$root/tests'
 	define.$fonts = '$root/fonts'
 	define.$textures = "$root/textures"
@@ -137,7 +139,7 @@
 			define.module[abs_path] = module
 
 			if(factory === null) return null // its not an AMD module, but accept that
-			if(!factory) throw new Error("Cannot find factory for module (file not found):" + abs_path)
+			if(!factory) throw new Error("Cannot find factory for module (file not found): " + dep_path + " > " + abs_path)
 
 			// call the factory
 			if(typeof factory == 'function'){
@@ -474,12 +476,12 @@
 		
 		var result;
 		var output = []
-		var result = str.match(/function\s*[\w]*\s*\(([\w,\s]*)\)/)
+		var result = str.match(/function\s*[$_\w]*\s*\(([$_\w,\s]*)\)/)
 
 		var map = result[1].split(/\s*,\s*/)
 		for(var i = 0; i<map.length; i++) if(map[i] !== '') output.push(map[i].toLowerCase().trim())
 
-		var matchrx = new RegExp(/define\.(?:render|class)\s*\(\s*(?:this\s*,\s*['"]\w+['"]\s*,\s*(?:\w+\s*,\s*){0,1}){0,1}function\s*[\w]*\s*\(([\w,\s]*)\)\s*{/g)
+		var matchrx = new RegExp(/define\.(?:render|class)\s*\(\s*(?:this\s*,\s*['"][$_\w]+['"]\s*,\s*(?:[$_\w]+\s*,\s*){0,1}){0,1}function\s*[$_\w]*\s*\(([$_\w,\s]*)\)\s*\{/g)
 		while((result = matchrx.exec(str)) !== null) {
 			var map = result[1].split(/\s*,\s*/)
 			for(var i = 0; i<map.length; i++)if(map[i] !== '') output.push(map[i].toLowerCase())
@@ -492,6 +494,9 @@
 	define.lookupClass = function(cls){
 		var luc = define.system_classes[cls]
 		if(luc !== undefined) return luc
+		if (cls.match(/^[a-zA-Z0-9_]+\$/)) {
+			return '$plugins/' + cls.replace(/\$/g, '/') + '.js'
+		}
 		return './' + cls
 	}
 

--- a/define.js
+++ b/define.js
@@ -494,9 +494,14 @@
 	define.lookupClass = function(cls){
 		var luc = define.system_classes[cls]
 		if(luc !== undefined) return luc
-		if (cls.match(/^[a-zA-Z0-9_]+\$/)) {
-			return '$plugins/' + cls.replace(/\$/g, '/') + '.js'
+
+		var match = /^([a-zA-Z0-9_]+\$[a-zA-Z0-9_$]+)/.exec(cls);
+		if (match) {
+			var comploc = match[1];
+			var remainder = cls.substr(comploc.length);
+			return '$plugins/' + comploc.replace(/\$/g, '/') + remainder;
 		}
+
 		return './' + cls
 	}
 


### PR DESCRIPTION
Now classes, screens and other objects from compositions can be used in other compositions, effectively unifying the composition/plugin package structure and making everything both a composition and a library for other compositions.

To use this feature simlink the base directory of external compositions into the ./compositions directory and then use "compname$classname" in your class definitions to automatically pull in those classes (see the ./compositions/sample/index.js to see an example of how it's being used).  